### PR TITLE
Add #filter to Just and Nothing

### DIFF
--- a/lib/or_else/just.rb
+++ b/lib/or_else/just.rb
@@ -13,6 +13,10 @@ module OrElse
       Maybe(yield value)
     end
 
+    def filter
+      (yield value) ? self : Nothing
+    end
+
     def empty?
       false
     end

--- a/lib/or_else/nothing_class.rb
+++ b/lib/or_else/nothing_class.rb
@@ -12,6 +12,10 @@ module OrElse
       Nothing
     end
 
+    def filter
+      Nothing
+    end
+
     def empty?
       true
     end

--- a/spec/or_else/just_spec.rb
+++ b/spec/or_else/just_spec.rb
@@ -60,6 +60,24 @@ module OrElse
       end
     end
 
+    describe '#filter' do
+      let(:val) { 1 }
+
+      specify { expect { |b| just.filter(&b) }.to yield_with_args(val) }
+
+      context 'when the predicate returns true' do
+        it 'returns the Just intact' do
+          expect(just.filter {|j| j == 1}).to eq just
+        end
+      end
+
+      context 'when the predicate returns false' do
+        it 'returns Nothing' do
+          expect(just.filter {|j| j != 1}).to eq Nothing
+        end
+      end
+    end
+
     describe '#empty?' do
       let(:val) { 1 }
 

--- a/spec/or_else/nothing_spec.rb
+++ b/spec/or_else/nothing_spec.rb
@@ -16,6 +16,10 @@ module OrElse
       specify { expect(nothing.flat_map).to eq Nothing }
     end
 
+    describe '#filter' do
+      specify { expect(nothing.filter).to eq Nothing }
+    end
+
     describe '#empty?' do
       specify { expect(nothing.empty?).to be true }
     end


### PR DESCRIPTION
Replicating the Scala capability of filtering on Option types.

Sample use case for the new code:

``` ruby
def process_something
  data = some_computation_returning_maybe
  data.filter(fulfills_condition)
      .map(transform_data)
      .filter(fulfills_another_condition)
end
```
